### PR TITLE
🐛 [Fixed] GPencilStroke has no attribute "draw_cyclic"

### DIFF
--- a/ds_utils/blender_utils.py
+++ b/ds_utils/blender_utils.py
@@ -291,7 +291,7 @@ def draw_segment(gp_frame: GPencilFrame, points: List[tuple], draw_cyclic=False,
     # Init new stroke
     gp_stroke = gp_frame.strokes.new()
     gp_stroke.display_mode = '3DSPACE'   # allows for editing
-    gp_stroke.draw_cyclic = draw_cyclic  # closes the stroke
+    gp_stroke.use_cyclic = draw_cyclic  # closes the stroke
     gp_stroke.material_index = material_index
 
     # Define stroke geometry
@@ -305,7 +305,7 @@ def draw_square(gp_frame: GPencilFrame, center: tuple, size: int, material_index
     # Init new stroke
     gp_stroke = gp_frame.strokes.new()
     gp_stroke.display_mode = '3DSPACE'  # allows for editing
-    gp_stroke.draw_cyclic = True        # closes the stroke
+    gp_stroke.use_cyclic = True        # closes the stroke
     gp_stroke.material_index = material_index
 
     # Define stroke geometry
@@ -322,7 +322,7 @@ def draw_circle(gp_frame: GPencilFrame, center: tuple, radius: float, segments: 
     # Init new stroke
     gp_stroke = gp_frame.strokes.new()
     gp_stroke.display_mode = '3DSPACE'  # allows for editing
-    gp_stroke.draw_cyclic = True        # closes the stroke
+    gp_stroke.use_cyclic = True        # closes the stroke
     gp_stroke.material_index = material_index
 
     # Define stroke geometry
@@ -341,7 +341,7 @@ def draw_cube(gp_frame: GPencilFrame, center: tuple, size: float, material_index
     # Init new stroke
     gp_stroke = gp_frame.strokes.new()
     gp_stroke.display_mode = '3DSPACE'  # allows for editing
-    gp_stroke.draw_cyclic = True  # closes the stroke
+    gp_stroke.use_cyclic = True  # closes the stroke
     gp_stroke.material_index = material_index
 
     # Define stroke geometry


### PR DESCRIPTION
Hello,

I'm currently doing some researches on morphogenesis in Blender and I found your code.
I wanted to run it on my computer and then had the following issue:
`
File "/home/felix/Documents/IA/PROJET/Recherches/Morphogenesis/data-science-learning/ds_utils/blender_utils.py", line 294, in draw_segment
gp_stroke.draw_cyclic = draw_cyclic  # closes the stroke
AttributeError: 'GPencilStroke' object has no attribute 'draw_cyclic'
Error: Python script failed, check the message in the system console
`
So I went on the Blender Python documentation and saw this: 
https://docs.blender.org/api/current/bpy.types.GPencilStroke.html?highlight=gpencilstr#bpy.types.GPencilStroke

I think the name of the attribute has changed.
I changed it on the corresponding file.

Now it seems to be working as intended.